### PR TITLE
Add an exclusion mechanism for refs.

### DIFF
--- a/pkg/interception/push/handler.go
+++ b/pkg/interception/push/handler.go
@@ -17,14 +17,19 @@ import (
 // It recognises the following request headers:
 //    X-GitHub-Event - this is provided by GitHub in its hook-mechanism
 //    Push-Ref - this is configured on the trigger interceptor
+//    PushExclude-Ref - this is configured on the trigger interceptor
 //    Push-Repo - this is the full name of the GitHub repo e.g.
 //    tektoncd/triggers.
 //
 // If a Push-Repo is provided, and no Push-Ref, then this will match on _all_
 // pushes from the Repo.
 //
+// If a Push-Repo is provided, and no Push-Ref, but a PushExclude-Ref is
+// provided, then the interceptor will match only if the hook's ref does not
+// match the excluded ref.
+//
 // If the request matches the configuration, the body is returned, with an
-// additional key added to the body: "intercepted.ref" which will be ths
+// additional key added to the body: "intercepted.ref" which will be the
 // shortened version of the ref extracting just the last part (the branch).
 func Handler(r *http.Request, body []byte) ([]byte, error) {
 	var event github.PushEvent

--- a/pkg/interception/push/handler_test.go
+++ b/pkg/interception/push/handler_test.go
@@ -22,7 +22,7 @@ func TestHandleWithSuccess(t *testing.T) {
 			ID: github.String("abc123456789"),
 		},
 	}
-	r := makeRequest(t, event, "push", "master")
+	r := makeRequest(t, event, "push", "master", "")
 	body := mustMarshal(t, event)
 	newBody, err := Handler(r, body)
 


### PR DESCRIPTION
This adds a simple header `PushExclude-Ref` for pushes, allowing exclusion of specific branches from matching.

In combination with `PushRef` being empty, this allows triggering on pushes to every branch, except for a named branch.